### PR TITLE
Fixed filtering issue for missing values

### DIFF
--- a/api/database.py
+++ b/api/database.py
@@ -172,6 +172,7 @@ def test_Tukey():
 def filter2(filter_id):
     base_filters = ['clinical_stage', 'pT_stage', 'pN_stage', 'pM_stage', 'Diff_grade', 'Neuralinv', 'Vascinv', 'PreOp_treatment_yesno', 'PostOp_type_treatment']
     data_filtered = db.data
+    data_filtered = data_filtered.fillna('missing')
     for key in base_filters:
         data_filtered = data_filtered[data_filtered[key].isin(filter_id[key])]
 
@@ -207,7 +208,7 @@ def filter2(filter_id):
 def filtering(filter_id):
     base_filters = ['clinical_stage', 'pT_stage', 'pN_stage', 'pM_stage', 'Diff_grade', 'Neuralinv', 'Vascinv', 'PreOp_treatment_yesno', 'PostOp_type_treatment']
     data_filtered = db.data
-
+    data_filtered = data_filtered.fillna('missing')
     data_filtered = data_filtered[lambda row: row.Tumor_type_code.isin(filter_id['tumors'])]
 
     for key in base_filters:

--- a/api/test.py
+++ b/api/test.py
@@ -374,20 +374,20 @@ def test_results_number():
     ex = deepcopy(example_body)
 
     c = filter2_to_dict(ex)
-
-    assert len(c) == 27580
+    
+    assert len(c) == 35532
 
     # Filter out cell types
     ex['cells'] = ['CD4_Treg', 'CD4']
     c = filter2_to_dict(ex)
-
-    assert len(c) == 3940
+    
+    assert len(c) == 5076
 
     # Using second example data
     ex = deepcopy(example_body2)
     c = filter2_to_dict(ex)
 
-    assert len(c) == 124
+    assert len(c) == 128
 
 test_results_number()
 

--- a/preprocess.py
+++ b/preprocess.py
@@ -167,7 +167,7 @@ def form_configuration():
     ]
 
     tumor_specific_values = []
-    for column in tumor_specific_column:
+    for column in tumor_specific_columns:
         # values = uniq(data[c][lambda x: ~pd.isnull(x)])
         # print(c, values)
         for tumor in tumor_types:


### PR DESCRIPTION
Related to #79
Fixes the problem with filtering where NA values where removed, leading to differences in the KM-Plot between the R and Python version